### PR TITLE
Fixed typo in the Object vs Class table

### DIFF
--- a/java_basicsI_and_oops/README.md
+++ b/java_basicsI_and_oops/README.md
@@ -149,8 +149,8 @@ NOTE : UTF-8 is the most popular unicode character encoding with 90% websites us
 <tr><td>Object is a <strong>physical</strong> entity.</td><td>Class is a <strong>logical</strong> entity.</td></tr>
 <tr><td>Object is created through <strong>new keyword</strong> mainly e.g. Student s1=new Student();</td><td>Class is declared using <strong>class keyword</strong> e.g. class Student{}</td></tr>
 <tr><td>Object is created <strong>many times</strong> as per requirement.</td><td>Class is declared <strong>once</strong>.</td></tr>
-<tr><td>Object <strong>allocates memory when it is created</strong>.</td><td>Class <strong>doesn't allocated memory when it is created</strong>.</td></tr>
-<tr><td>There are <strong>many ways to create object</strong> like new keyword, newInstance() method, clone() method, factory method & deserialization.</td><td>There is only <strong>one way to define class</strong> in java using class keyword.</td></tr>
+<tr><td>Object <strong>allocates memory when it is created</strong>.</td><td>Class <strong>doesn't allocate memory when it is created</strong>.</td></tr>
+<tr><td>There are <strong>many ways to create an object</strong> like new keyword, newInstance() method, clone() method, factory method & deserialization.</td><td>There is only <strong>one way to define class</strong> in java using class keyword.</td></tr>
 </tbody></table>
 
 ## Constructors vs Methods


### PR DESCRIPTION
### Describe your change
Fixes small typo issue in the Object vs Class table.
- "doesn't allocated" -> "doesn't allocate"
- "many ways to create object" -> "many ways to create an object"